### PR TITLE
Use client side filtering

### DIFF
--- a/src/components/TransactionListItem.tsx
+++ b/src/components/TransactionListItem.tsx
@@ -51,7 +51,7 @@ export default function TransactionListItem({
             </Text>
             <Text style={{ color: Colors.grayShades[500] }}>
               &nbsp;
-              {humanize.date(item.completed_at)}
+              {humanize.date(item.created_at)}
             </Text>
           </View>
         </View>


### PR DESCRIPTION
This PR aims to change how we filter & sort data, from inside the `getTransactions` function, into something I named as "client-side filtering". We implement the sort and filter logic inside useQuery's `select` options.